### PR TITLE
Default alpha blend

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,11 +172,15 @@ If --username and/or --dbname are not specified the current username is used as 
 
   --copyright                     (Default: '') glTF asset copyright
 
-  --default_color                 (Default: #FFFFFF) Default color
+  --default_color                 (Default: #FFFFFF) Default color, in (A)RGB order
 
   --default_metallic_roughness    (Default: #008000) Default metallic roughness
 
   --double_sided                  (Default: true) Default double sided
+  
+  --default_alpha_mode            (Default: OPAQUE) Default glTF material
+                                  AlphaMode. Other values: BLEND and MASK.
+                                  Defines how the alpha value is interpreted.
 
   --create_gltf                   (Default: true) Create glTF files
 

--- a/src/b3dm.tileset/QuadtreeTiler.cs
+++ b/src/b3dm.tileset/QuadtreeTiler.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using B3dm.Tileset;
 using B3dm.Tileset.Extensions;
 using Npgsql;
+using SharpGLTF.Materials;
 using subtree;
 using Wkx;
 
@@ -47,7 +48,7 @@ public class QuadtreeTiler
         this.radiusColumn = radiusColumn;
     }
 
-    public List<Tile> GenerateTiles(BoundingBox bbox, Tile tile, List<Tile> tiles, int lod = 0, bool addOutlines = false, string defaultColor = "#FFFFFF", string defaultMetallicRoughness = "#008000", bool doubleSided = true, bool createGltf = false)
+    public List<Tile> GenerateTiles(BoundingBox bbox, Tile tile, List<Tile> tiles, int lod = 0, bool addOutlines = false, string defaultColor = "#FFFFFF", string defaultMetallicRoughness = "#008000", bool doubleSided = true, AlphaMode defaultAlphaMode = AlphaMode.OPAQUE, bool createGltf = false)
     {
         var where = (query != string.Empty ? $" and {query}" : String.Empty);
 
@@ -83,7 +84,7 @@ public class QuadtreeTiler
                     var bboxQuad = new BoundingBox(xstart, ystart, xend, yend);
                     var new_tile = new Tile(z, tile.X * 2 + x, tile.Y * 2 + y);
                     new_tile.BoundingBox = bboxQuad.ToArray();
-                    GenerateTiles(bboxQuad, new_tile, tiles, lod, addOutlines, defaultColor, defaultMetallicRoughness, doubleSided, createGltf);
+                    GenerateTiles(bboxQuad, new_tile, tiles, lod, addOutlines, defaultColor, defaultMetallicRoughness, doubleSided, defaultAlphaMode, createGltf);
                 }
             }
         }
@@ -107,7 +108,7 @@ public class QuadtreeTiler
 
                 var geometries = GeometryRepository.GetGeometrySubset(conn, table, geometryColumn, tile.BoundingBox, source_epsg, target_srs, colorColumn, attributesColumn, where, radiusColumn);
                 // var scale = new double[] { 1, 1, 1 };
-                bytes = TileWriter.ToTile(geometries, translation, copyright: copyright, addOutlines: addOutlines, defaultColor: defaultColor, defaultMetallicRoughness: defaultMetallicRoughness, doubleSided: doubleSided, createGltf: createGltf);
+                bytes = TileWriter.ToTile(geometries, translation, copyright: copyright, addOutlines: addOutlines, defaultColor: defaultColor, defaultMetallicRoughness: defaultMetallicRoughness, doubleSided: doubleSided, defaultAlphaMode: defaultAlphaMode, createGltf: createGltf);
                 if (bytes != null) {
 
                     tile.Lod = lod;
@@ -123,7 +124,7 @@ public class QuadtreeTiler
                             // make a copy of the tile 
                             var t2 = new Tile(tile.Z, tile.X, tile.Y);
                             t2.BoundingBox = tile.BoundingBox;
-                            var lodNextTiles = GenerateTiles(bbox, t2, new List<Tile>(), nextLod, addOutlines, defaultColor, defaultMetallicRoughness, doubleSided, createGltf);
+                            var lodNextTiles = GenerateTiles(bbox, t2, new List<Tile>(), nextLod, addOutlines, defaultColor, defaultMetallicRoughness, doubleSided, defaultAlphaMode, createGltf);
                             tile.Children = lodNextTiles;
                         };
                     }

--- a/src/pg2b3dm/Options.cs
+++ b/src/pg2b3dm/Options.cs
@@ -1,5 +1,5 @@
 using CommandLine;
-using AlphaMode = SharpGLTF.Materials.AlphaMode;
+using SharpGLTF.Materials;
 
 namespace pg2b3dm;
 

--- a/src/pg2b3dm/Options.cs
+++ b/src/pg2b3dm/Options.cs
@@ -29,7 +29,7 @@ public class Options
     [Option("copyright", Required = false, Default = "", HelpText = "glTF asset copyright")]
     public string Copyright { get; set; }
 
-    [Option("default_color", Required = false, Default = "#FFFFFF", HelpText = "Default color")]
+    [Option("default_color", Required = false, Default = "#FFFFFF", HelpText = "Default color, in (A)RGB order")]
     public string DefaultColor { get; set; }
 
     [Option("default_metallic_roughness", Required = false, Default = "#008000", HelpText = "Default metallic roughness")]
@@ -38,7 +38,7 @@ public class Options
     [Option("double_sided", Required = false, Default = true, HelpText = "double sided")]
     public bool? DoubleSided { get; set; }
     
-    [Option("default_alpha_mode", Required = false, Default = AlphaMode.OPAQUE, HelpText = "Default AlphaMode")]
+    [Option("default_alpha_mode", Required = false, Default = AlphaMode.OPAQUE, HelpText = "Default glTF material AlphaMode. Other values: BLEND and MASK. Defines how the alpha value is interpreted.")]
     public AlphaMode DefaultAlphaMode { get; set; }
 
     [Option("create_gltf", Required = false, Default = true, HelpText = "Create glTF")]

--- a/src/pg2b3dm/Options.cs
+++ b/src/pg2b3dm/Options.cs
@@ -1,4 +1,5 @@
 using CommandLine;
+using AlphaMode = SharpGLTF.Materials.AlphaMode;
 
 namespace pg2b3dm;
 
@@ -36,6 +37,9 @@ public class Options
 
     [Option("double_sided", Required = false, Default = true, HelpText = "double sided")]
     public bool? DoubleSided { get; set; }
+    
+    [Option("default_alpha_mode", Required = false, Default = AlphaMode.OPAQUE, HelpText = "Default AlphaMode")]
+    public AlphaMode DefaultAlphaMode { get; set; }
 
     [Option("create_gltf", Required = false, Default = true, HelpText = "Create glTF")]
     public bool? CreateGltf { get; set; }

--- a/src/pg2b3dm/Program.cs
+++ b/src/pg2b3dm/Program.cs
@@ -56,6 +56,7 @@ class Program
             var defaultColor = o.DefaultColor;
             var defaultMetallicRoughness = o.DefaultMetallicRoughness;
             var doubleSided = (bool)o.DoubleSided;
+            var defaultAlphaMode = o.DefaultAlphaMode;
             var createGltf = (bool)o.CreateGltf;
             var outputDirectory = o.Output;
             var zoom = o.Zoom;
@@ -111,6 +112,7 @@ class Program
             Console.WriteLine($"Default color: {defaultColor}");
             Console.WriteLine($"Default metallic roughness: {defaultMetallicRoughness}");
             Console.WriteLine($"Doublesided: {doubleSided}");
+            Console.WriteLine($"Default AlphaMode: {defaultAlphaMode}");
             Console.WriteLine($"Create glTF tiles: {createGltf}");
 
             var att = !string.IsNullOrEmpty(o.AttributeColumns) ? o.AttributeColumns : "-";
@@ -184,7 +186,7 @@ class Program
                 tile.BoundingBox = bbox.ToArray();
                 Console.WriteLine($"Start generating tiles...");
                 var quadtreeTiler = new QuadtreeTiler(conn, table, source_epsg, geometryColumn, o.MaxFeaturesPerTile, query, translation, o.ShadersColumn, o.AttributeColumns, lodcolumn, contentDirectory, lods, o.Copyright, skipCreateTiles, o.RadiusColumn);
-                var tiles = quadtreeTiler.GenerateTiles(bbox, tile, new List<Tile>(), lodcolumn != string.Empty ? lods.First() : 0, addOutlines, defaultColor, defaultMetallicRoughness, doubleSided, createGltf);
+                var tiles = quadtreeTiler.GenerateTiles(bbox, tile, new List<Tile>(), lodcolumn != string.Empty ? lods.First() : 0, addOutlines, defaultColor, defaultMetallicRoughness, doubleSided, defaultAlphaMode, createGltf);
                 Console.WriteLine();
                 Console.WriteLine("Tiles created: " + tiles.Count(tile => tile.Available));
 

--- a/src/wkb2gltf.core.tests/ColorTests.cs
+++ b/src/wkb2gltf.core.tests/ColorTests.cs
@@ -12,4 +12,12 @@ public class ColorTests
         var color = ColorTranslator.FromHtml(hexcolor);
         Assert.That(color.R == 255 && color.G == 85 && color.B == 85, Is.True);
     }
+    
+    [Test]
+    public void HexColorWithAlphaToRgbaTest()
+    {
+        var hexcolor = "#55ff5657";
+        var color = ColorTranslator.FromHtml(hexcolor);
+        Assert.That(color.A == 85 && color.R == 255 && color.G == 86 && color.B == 87, Is.True);
+    }
 }

--- a/src/wkb2gltf.core.tests/MaterialCreatorTests.cs
+++ b/src/wkb2gltf.core.tests/MaterialCreatorTests.cs
@@ -29,12 +29,12 @@ public class MaterialCreatorTests
     {
         // arrange
         var shader = new Shader();
-        // #008000 = green https://www.color-hex.com/color/008000 (0,128,0))
-        shader.PbrMetallicRoughness = new PbrMetallicRoughness() { BaseColor = "#008000", MetallicRoughness = "" };
+        // #008000 = green https://www.color-hex.com/color/008000 (0,128,0)), 81 as Alpha value
+        shader.PbrMetallicRoughness = new PbrMetallicRoughness() { BaseColor = "#81008000", MetallicRoughness = "" };
 
 
         // act
-        var material = MaterialCreator.CreateMaterial(shader);
+        var material = MaterialCreator.CreateMaterial(shader, true, AlphaMode.BLEND);
 
         // asssert
         Assert.That(material != null);
@@ -42,7 +42,7 @@ public class MaterialCreatorTests
         Assert.That(rgba.X == 0, Is.True);
         Assert.That(Math.Round(rgba.Y * 255) == 128, Is.True);
         Assert.That(rgba.Z == 0, Is.True);
-        Assert.That(rgba.W == 1, Is.True);
+        Assert.That(Math.Round(rgba.W * 255) == 129, Is.True);
 
         SaveSampleModel(material, "basecolor");
     }

--- a/src/wkb2gltf.core.tests/MaterialCreatorTests.cs
+++ b/src/wkb2gltf.core.tests/MaterialCreatorTests.cs
@@ -71,7 +71,7 @@ public class MaterialCreatorTests
         Assert.That(Math.Round(emissiveVector3.X * 255), Is.EqualTo(emissive.X));
         Assert.That(Math.Round(emissiveVector3.Y * 255), Is.EqualTo(emissive.Y));
         Assert.That(Math.Round(emissiveVector3.Z * 255), Is.EqualTo(emissive.Z));
-        SaveSampleModel(material, "basecolor");
+        SaveSampleModel(material, "emmisive");
     }
 
 

--- a/src/wkb2gltf.core/GlbCreator.cs
+++ b/src/wkb2gltf.core/GlbCreator.cs
@@ -11,13 +11,12 @@ using SharpGLTF.Schema2;
 using SharpGLTF.Schema2.Tiles3D;
 using Wkb2Gltf.extensions;
 using Wkb2Gltf.Extensions;
-using AlphaMode = SharpGLTF.Materials.AlphaMode;
 
 namespace Wkb2Gltf;
 
 public static class GlbCreator
 {
-    public static byte[] GetGlb(List<List<Triangle>> triangles, string copyright = "", bool addOutlines = false, string defaultColor = "#FFFFFF", string defaultMetallicRoughness = "#008000", bool defaultDoubleSided = true, Dictionary<string, List<object>> attributes = null, bool createGltf = false, AlphaMode defaultAlphaMode = AlphaMode.OPAQUE, bool doubleSided = false, bool YAxisUp = true)
+    public static byte[] GetGlb(List<List<Triangle>> triangles, string copyright = "", bool addOutlines = false, string defaultColor = "#FFFFFF", string defaultMetallicRoughness = "#008000", bool defaultDoubleSided = true, Dictionary<string, List<object>> attributes = null, bool createGltf = false, SharpGLTF.Materials.AlphaMode defaultAlphaMode = SharpGLTF.Materials.AlphaMode.OPAQUE, bool doubleSided = false, bool YAxisUp = true)
     {
         var materialCache = new MaterialsCache();
         var shader = new Shader();

--- a/src/wkb2gltf.core/GlbCreator.cs
+++ b/src/wkb2gltf.core/GlbCreator.cs
@@ -11,17 +11,18 @@ using SharpGLTF.Schema2;
 using SharpGLTF.Schema2.Tiles3D;
 using Wkb2Gltf.extensions;
 using Wkb2Gltf.Extensions;
+using AlphaMode = SharpGLTF.Materials.AlphaMode;
 
 namespace Wkb2Gltf;
 
 public static class GlbCreator
 {
-    public static byte[] GetGlb(List<List<Triangle>> triangles, string copyright = "", bool addOutlines = false, string defaultColor = "#FFFFFF", string defaultMetallicRoughness = "#008000", bool defaultDoubleSided = true, Dictionary<string, List<object>> attributes = null, bool createGltf = false, bool doubleSided = false, bool YAxisUp = true)
+    public static byte[] GetGlb(List<List<Triangle>> triangles, string copyright = "", bool addOutlines = false, string defaultColor = "#FFFFFF", string defaultMetallicRoughness = "#008000", bool defaultDoubleSided = true, Dictionary<string, List<object>> attributes = null, bool createGltf = false, AlphaMode defaultAlphaMode = AlphaMode.OPAQUE, bool doubleSided = false, bool YAxisUp = true)
     {
         var materialCache = new MaterialsCache();
         var shader = new Shader();
         shader.PbrMetallicRoughness = new PbrMetallicRoughness() { BaseColor = defaultColor, MetallicRoughness = defaultMetallicRoughness };
-        var defaultMaterial = MaterialCreator.CreateMaterial(shader, defaultDoubleSided);
+        var defaultMaterial = MaterialCreator.CreateMaterial(shader, defaultDoubleSided, defaultAlphaMode);
 
         var meshBatchId = new MeshBuilder<VertexPositionNormal, VertexWithBatchId, VertexEmpty>("mesh");
         var meshFeatureIds = new MeshBuilder<VertexPositionNormal, VertexWithFeatureId, VertexEmpty>("mesh");
@@ -31,7 +32,7 @@ public static class GlbCreator
                 MaterialBuilder material;
 
                 if (triangle.Shader != null) {
-                    material = materialCache.GetMaterialBuilderByShader(triangle.Shader, doubleSided);
+                    material = materialCache.GetMaterialBuilderByShader(triangle.Shader, doubleSided, defaultAlphaMode);
                 }
                 else {
                     material = defaultMaterial;

--- a/src/wkb2gltf.core/MaterialCreator.cs
+++ b/src/wkb2gltf.core/MaterialCreator.cs
@@ -6,11 +6,11 @@ namespace Wkb2Gltf;
 
 public class MaterialCreator
 {
-    public static MaterialBuilder CreateMaterial(Shader shader, bool defaultDoubleSided = true)
+    public static MaterialBuilder CreateMaterial(Shader shader, bool defaultDoubleSided = true, AlphaMode defaultAlphaMode = AlphaMode.OPAQUE)
     {
         var material = new MaterialBuilder().
             WithDoubleSide(defaultDoubleSided).
-            WithAlpha(AlphaMode.OPAQUE);
+            WithAlpha(defaultAlphaMode);
 
         if (!string.IsNullOrEmpty(shader.EmissiveColor)) {
             material.WithEmissive(ColorToVector3(ColorTranslator.FromHtml(shader.EmissiveColor)));

--- a/src/wkb2gltf.core/MaterialsCache.cs
+++ b/src/wkb2gltf.core/MaterialsCache.cs
@@ -12,11 +12,11 @@ public class MaterialsCache
         materials = new List<MaterialAndShader>();
     }
 
-    public MaterialBuilder GetMaterialBuilderByShader(Shader shader, bool doubleSided = false)
+    public MaterialBuilder GetMaterialBuilderByShader(Shader shader, bool doubleSided = false, AlphaMode defaultAlphaMode = AlphaMode.OPAQUE)
     {
         var res = (from m in materials where m.Shader.Equals(shader) select m).FirstOrDefault();
         if (res == null) {
-            var materialBuilder = MaterialCreator.CreateMaterial(shader, doubleSided);
+            var materialBuilder = MaterialCreator.CreateMaterial(shader, doubleSided, defaultAlphaMode);
 
             res = new MaterialAndShader { Shader = shader, MaterialBuilder = materialBuilder };
             materials.Add(res);

--- a/src/wkb2gltf.core/TileCreator.cs
+++ b/src/wkb2gltf.core/TileCreator.cs
@@ -2,14 +2,15 @@
 using System.Linq;
 using B3dmCore;
 using Newtonsoft.Json;
+using SharpGLTF.Materials;
 
 namespace Wkb2Gltf;
 
 public static class TileCreator
 {
-    public static byte[] GetTile(Dictionary<string, List<object>> attributes, List<List<Triangle>> triangleCollection, string copyright = "", bool addOutlines = false, string defaultColor = "#FFFFFF", string defaultMetallicRoughness = "#008000", bool doubleSided = true, bool createGltf = false, bool YAxisUp = true)
+    public static byte[] GetTile(Dictionary<string, List<object>> attributes, List<List<Triangle>> triangleCollection, string copyright = "", bool addOutlines = false, string defaultColor = "#FFFFFF", string defaultMetallicRoughness = "#008000", bool doubleSided = true, AlphaMode defaultAlphaMode = AlphaMode.OPAQUE, bool createGltf = false, bool YAxisUp = true)
     {
-        var bytes = GlbCreator.GetGlb(triangleCollection, copyright, addOutlines, defaultColor, defaultMetallicRoughness, doubleSided, attributes, createGltf, doubleSided, YAxisUp);
+        var bytes = GlbCreator.GetGlb(triangleCollection, copyright, addOutlines, defaultColor, defaultMetallicRoughness, doubleSided, attributes, createGltf, defaultAlphaMode, doubleSided, YAxisUp);
 
         if(bytes== null) {
             return null;

--- a/src/wkb2gltf.core/TileWriter.cs
+++ b/src/wkb2gltf.core/TileWriter.cs
@@ -1,16 +1,17 @@
 ﻿using System.Collections.Generic;
+using SharpGLTF.Materials;
 using Wkb2Gltf;
 
 namespace pg2b3dm;
 
 public static class TileWriter
 {
-    public static byte[] ToTile(List<GeometryRecord> geometries, double[] translation = null, double[] scale = null, string copyright = "", bool addOutlines = false, string defaultColor = "#FFFFFF", string defaultMetallicRoughness = "#008000", bool doubleSided = true, bool createGltf = false, bool YAxisUp = true)
+    public static byte[] ToTile(List<GeometryRecord> geometries, double[] translation = null, double[] scale = null, string copyright = "", bool addOutlines = false, string defaultColor = "#FFFFFF", string defaultMetallicRoughness = "#008000", bool doubleSided = true, AlphaMode defaultAlphaMode = AlphaMode.OPAQUE, bool createGltf = false, bool YAxisUp = true)
     {
         var triangles = GetTriangles(geometries, translation, scale);
         var attributes = GetAttributes(geometries);
 
-        var bytes = TileCreator.GetTile(attributes, triangles, copyright, addOutlines, defaultColor, defaultMetallicRoughness, doubleSided, createGltf, YAxisUp);
+        var bytes = TileCreator.GetTile(attributes, triangles, copyright, addOutlines, defaultColor, defaultMetallicRoughness, doubleSided, defaultAlphaMode, createGltf, YAxisUp);
 
         return bytes;
     }

--- a/styling.md
+++ b/styling.md
@@ -62,7 +62,6 @@ Metallic factor: 0, Roughness factor: 0.5019608 (128/255)
 
 - Doubleside: true (option double_sided)
 
-- Alpha: 0 (hardcoded)
 
 Alternative option is to specify a shader using the ShadersColumn.
 
@@ -270,6 +269,11 @@ Converted to RGBA:
 (230, 0, 128, 0)
 
 So Diffuse Red = 230, Diffuse Green = 0, Diffuse Blue = 128, Alpha = 0
+
+### AlphaMode
+
+It is possible to specify glTF material alphaMode property (see: https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#alpha-coverage) using `--default_alpha_mode` option for all materials. By default it is set to OPAQUE. Other options are BLEND and MASK.
+Using non OPAQUE default alpha mode for all materials might affect rendering performance. It should be used only when most of the materials have alpha value different than 1. 
 
 ### Remarks
 


### PR DESCRIPTION
changes:
- add option to set default alpha mode
- fix filename conflict in color test

refs: #192 

I am not sure about using "using" keyword in C# never really developed in C#. The way it was used was mostly suggested by IDE.
If all goes well I can try to add it to Wkb2Gltf.Shader in another PR.