### PR TITLE
change 2 defaults (use_implicit_tiling + geometricerrors)

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,11 +192,11 @@ If --username and/or --dbname are not specified the current username is used as 
 
   -l, --lodcolumn                 (Default: '') LOD column (Cesium)
 
-  -g, --geometricerrors           (Default: 2000,0) Geometric errors (Cesium)
+  -g, --geometricerrors           (Default: 1000,0) Geometric errors (Cesium)
 
   --shaderscolumn                 (Default: '') shaders column (Cesium)
 
-  --use_implicit_tiling           (Default: true) use 1.1 implicit tiling (Cesium)
+  --use_implicit_tiling           (Default: false) use 1.1 implicit tiling (Cesium)
 
   --add_outlines                  (Default: false) Add outlines (Cesium)
 

--- a/src/b3dm.tileset/QuadtreeTiler.cs
+++ b/src/b3dm.tileset/QuadtreeTiler.cs
@@ -139,6 +139,9 @@ public class QuadtreeTiler
             }
 
             tile.Available = bytes != null ? true : false;
+            if(skipCreateTiles) {
+                tile.Available = true;
+            }
             tiles.Add(tile);
         }
 

--- a/src/pg2b3dm/Options.cs
+++ b/src/pg2b3dm/Options.cs
@@ -60,10 +60,10 @@ public class Options
     [Option('l', "lodcolumn", Required = false, Default = "", HelpText = "LOD column (Cesium)", SetName = "Cesium")]
     public string LodColumn { get; set; }
 
-    [Option('g', "geometricerrors", Required = false, Default = "2000,0", HelpText = "Geometric errors (Cesium)", SetName = "Cesium")]
+    [Option('g', "geometricerrors", Required = false, Default = "1000,0", HelpText = "Geometric errors (Cesium)", SetName = "Cesium")]
     public string GeometricErrors { get; set; }
 
-    [Option("use_implicit_tiling", Required = false, Default = true, HelpText = "use 1.1 implicit tiling (Cesium)", SetName = "Cesium")]
+    [Option("use_implicit_tiling", Required = false, Default = false, HelpText = "use 1.1 implicit tiling (Cesium)", SetName = "Cesium")]
     public bool? UseImplicitTiling { get; set; }
 
     [Option("add_outlines", Required = false, Default = false, HelpText = "Add outlines (Cesium)", SetName = "Cesium")]

--- a/src/wkb2gltf.core/extensions/PointExtensions.cs
+++ b/src/wkb2gltf.core/extensions/PointExtensions.cs
@@ -15,6 +15,9 @@ public static class PointExtensions
         var x = p.X - other.X;
         var y = p.Y - other.Y;
         var z = p.Z - other.Z;
+        if (z == null) {
+            z = 0;
+        }
         return new Vector3((float)x,(float)y,(float)z);
     }
 }


### PR DESCRIPTION
Change defaults:

- use_implicit_tiling from true to false

reason: Implicit tiling is giving issues with large geometries and display in Cesium

- geometricerrors from 2000,0 to 1000,0

reason: when tiling a larger area (for buildings) a lot of tile requests are done when using max geometric error = 2000
