### PR TITLE
use opaque mode when basecolor is opaque

### DIFF
--- a/src/wkb2gltf.core.tests/ShaderTests.cs
+++ b/src/wkb2gltf.core.tests/ShaderTests.cs
@@ -5,6 +5,19 @@ namespace Wkb2Gltf.Tests;
 public class ShaderTests
 {
     [Test]
+    public void TestShaderOpaque()
+    {
+        var shader = new Shader();
+        shader.PbrMetallicRoughness = new PbrMetallicRoughness() {
+            BaseColor = "#ff0000ff"
+        };
+        var isOpaque = shader.PbrMetallicRoughness.IsBaseColorOpaque();
+
+        Assert.That(isOpaque, Is.True);
+    }
+
+
+    [Test]
 
     public void ShaderEqualsTest()
     {

--- a/src/wkb2gltf.core.tests/ShaderTests.cs
+++ b/src/wkb2gltf.core.tests/ShaderTests.cs
@@ -7,13 +7,20 @@ public class ShaderTests
     [Test]
     public void TestShaderOpaque()
     {
-        var shader = new Shader();
-        shader.PbrMetallicRoughness = new PbrMetallicRoughness() {
+        var pbr = new PbrMetallicRoughness() {
             BaseColor = "#ff0000ff"
         };
-        var isOpaque = shader.PbrMetallicRoughness.IsBaseColorOpaque();
 
-        Assert.That(isOpaque, Is.True);
+        Assert.That(pbr.IsBaseColorOpaque(), Is.True);
+
+        pbr.BaseColor = "#ff0000";
+        Assert.That(pbr.IsBaseColorOpaque(), Is.True);
+
+        pbr.BaseColor = "#ff000053";
+        Assert.That(pbr.IsBaseColorOpaque(), Is.False);
+
+
+
     }
 
 

--- a/src/wkb2gltf.core/GlbCreator.cs
+++ b/src/wkb2gltf.core/GlbCreator.cs
@@ -21,6 +21,7 @@ public static class GlbCreator
         var materialCache = new MaterialsCache();
         var shader = new Shader();
         shader.PbrMetallicRoughness = new PbrMetallicRoughness() { BaseColor = defaultColor, MetallicRoughness = defaultMetallicRoughness };
+
         var defaultMaterial = MaterialCreator.CreateMaterial(shader, defaultDoubleSided, defaultAlphaMode);
 
         var meshBatchId = new MeshBuilder<VertexPositionNormal, VertexWithBatchId, VertexEmpty>("mesh");
@@ -31,6 +32,10 @@ public static class GlbCreator
                 MaterialBuilder material;
 
                 if (triangle.Shader != null) {
+                    if (triangle.Shader.PbrMetallicRoughness!=null && triangle.Shader.PbrMetallicRoughness.IsBaseColorOpaque()) {
+                        defaultAlphaMode = SharpGLTF.Materials.AlphaMode.OPAQUE;
+                    }
+
                     material = materialCache.GetMaterialBuilderByShader(triangle.Shader, doubleSided, defaultAlphaMode);
                 }
                 else {

--- a/src/wkb2gltf.core/PbrMetallicRoughness.cs
+++ b/src/wkb2gltf.core/PbrMetallicRoughness.cs
@@ -21,4 +21,15 @@ public class PbrMetallicRoughness
         return base.GetHashCode();
     }
 
+    public bool IsBaseColorOpaque()
+    {
+        if (BaseColor.Length == 9) {
+            var alpha = BaseColor.Substring(7, 2);
+            if (alpha.ToUpper() == "FF") {
+                return true;
+            }
+            return false;
+        }
+        return true;
+    }
 }

--- a/styling.md
+++ b/styling.md
@@ -277,7 +277,11 @@ So Diffuse Red = 230, Diffuse Green = 0, Diffuse Blue = 128, Alpha = 0
 ### AlphaMode
 
 It is possible to specify glTF material alphaMode property (see: https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#alpha-coverage) using `--default_alpha_mode` option for all materials. By default it is set to OPAQUE. Other options are BLEND and MASK.
-Using non OPAQUE default alpha mode for all materials might affect rendering performance. It should be used only when most of the materials have alpha value different than 1.
+Using non OPAQUE default alpha mode for all materials might affect rendering performance.
+
+When a color has 6 digits (like #RRGGBB) then alphaMode is set to OPAQUE for that material.
+
+When a color has 8 digits (like #RRGGBBAA) and AA is equal to 255 (0xFF) then alphaMode is set to OPAQUE for that material.
 
 Sample setting alpha mode to BLEND for 50% transparent polygon in Amsterdam:
 


### PR DESCRIPTION
workaround for visualizing in Cesium materials which are fully opaque and alpha mode = BLEND -> set alphamode to OPAQUE