### PR TITLE
Add --theme option to select 3DCityDB v5 textures by appearance theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ If `--connection` is not specified and none of the deprecated database parameter
 
   -q, --query                     (Default: '') Query parameter
 
+  --theme                         (Default: '') 3DCityDB v5+ appearance theme to
+                                  select textures from (filters the surface_data
+                                  via appearance). Empty = no theme filter
+                                  (lowest surface_data_id wins).
+
   --copyright                     (Default: '') glTF asset copyright
 
   --default_color                 (Default: #FFFFFF) Default color, in RGB(A) order

--- a/dataprocessing/dataprocessing_citygml.md
+++ b/dataprocessing/dataprocessing_citygml.md
@@ -211,6 +211,29 @@ Priority rule during export:
 - If textures and shaders are both available in the same tile, textures are used.
 - Tiles without texture data keep existing shader/default behavior.
 
+### Selecting an appearance theme
+
+One geometry can carry textures from several appearance themes (for example an aerial photo theme next to
+thematic analysis layers). Themes live in `citydb.appearance.theme` and are linked to the textures through
+`citydb.appear_to_surface_data`. List the available themes with:
+
+```sql
+SELECT DISTINCT theme FROM citydb.appearance;
+```
+
+Use the `--theme` option to export the textures of one theme:
+
+```bash
+pg2b3dm --connection "Host=localhost;Port=5440;Username=postgres;Database=postgres;CommandTimeOut=0" -t citydb.geometry_data -c geometry --theme <theme>
+```
+
+Notes:
+
+- Without `--theme` the export is unchanged: no theme filter is applied and, for a geometry with multiple
+  mappings, the lowest `surface_data_id` wins.
+- Run pg2b3dm once per theme (into separate output folders) to publish one tileset per theme from the same
+  geometry, instead of duplicating the geometry per theme.
+
 Sample World Port Center Rotterdam:
 
 <img width="986" height="948" alt="image" src="https://github.com/user-attachments/assets/1e434d3f-7918-4b9b-87e6-18f168f45b55" />

--- a/src/b3dm.tileset/CityDbRepository.cs
+++ b/src/b3dm.tileset/CityDbRepository.cs
@@ -46,6 +46,20 @@ SELECT EXISTS (
         return ExecuteBooleanScalar(conn, sql);
     }
 
+    public static bool HasTheme(NpgsqlConnection conn, string theme)
+    {
+        const string sql = @"
+SELECT EXISTS (
+    SELECT 1
+    FROM citydb.appearance
+    WHERE theme = @theme
+)";
+
+        return ExecuteBooleanScalar(conn, sql, cmd => {
+            cmd.Parameters.AddWithValue("theme", theme);
+        });
+    }
+
     public static bool HasColumn(NpgsqlConnection conn, string tableName, string columnName)
     {
         var schemaAndTable = GetSchemaAndTable(tableName);

--- a/src/b3dm.tileset/GeometryRepository.cs
+++ b/src/b3dm.tileset/GeometryRepository.cs
@@ -203,7 +203,8 @@ public static class GeometryRepository
         // constrained to that appearance theme. Uses an EXISTS semi-join, not a JOIN, so a
         // surface_data referenced by several appearances sharing the theme yields one row,
         // not N duplicate textures.
-        var themeFilter = theme != string.Empty ? @"
+        var hasTheme = !string.IsNullOrWhiteSpace(theme);
+        var themeFilter = hasTheme ? @"
   AND EXISTS (
     SELECT 1
     FROM citydb.appear_to_surface_data a2s
@@ -232,7 +233,7 @@ ORDER BY g.id, sdm.surface_data_id";
         conn.Open();
         var cmd = new NpgsqlCommand(sql, conn);
         cmd.Parameters.AddWithValue("ids", sourceIds);
-        if (theme != string.Empty) {
+        if (hasTheme) {
             cmd.Parameters.AddWithValue("theme", theme);
         }
         var reader = cmd.ExecuteReader();

--- a/src/b3dm.tileset/GeometryRepository.cs
+++ b/src/b3dm.tileset/GeometryRepository.cs
@@ -38,7 +38,7 @@ public static class GeometryRepository
         return result;
     }
 
-    public static List<GeometryRecord> GetGeometrySubset(NpgsqlConnection conn, string geometry_table, string geometry_column, double[] bbox, int source_epsg, int target_srs, string shaderColumn = "", string attributesColumns = "", string query = "", string radiusColumn = "", bool keepProjection = false, string idColumn = "", bool includeTextures = false)
+    public static List<GeometryRecord> GetGeometrySubset(NpgsqlConnection conn, string geometry_table, string geometry_column, double[] bbox, int source_epsg, int target_srs, string shaderColumn = "", string attributesColumns = "", string query = "", string radiusColumn = "", bool keepProjection = false, string idColumn = "", bool includeTextures = false, string theme = "")
     {
         var sqlselect = GetSqlSelect(geometry_column, shaderColumn, attributesColumns, radiusColumn, target_srs, idColumn);
         var sqlFrom = "FROM " + geometry_table;
@@ -51,7 +51,7 @@ public static class GeometryRepository
 
         var geometries = GetGeometries(conn, shaderColumn, attributesColumns, sql, radiusColumn, idColumn);
         if (includeTextures) {
-            EnrichWithTextures(conn, geometries);
+            EnrichWithTextures(conn, geometries, theme);
         }
         return geometries;
     }
@@ -181,7 +181,7 @@ public static class GeometryRepository
         return geometries;
     }
 
-    private static void EnrichWithTextures(NpgsqlConnection conn, List<GeometryRecord> geometries)
+    private static void EnrichWithTextures(NpgsqlConnection conn, List<GeometryRecord> geometries, string theme = "")
     {
         var sourceIds = geometries
             .Where(g => g.SourceId.HasValue)
@@ -198,7 +198,17 @@ public static class GeometryRepository
             .GroupBy(g => g.SourceId!.Value)
             .ToDictionary(g => g.Key, g => g.First());
 
-        const string sql = @"
+        // Optional appearance-theme filter: without it the query keeps its original shape
+        // (lowest surface_data_id wins per geometry); with a theme the surface_data is
+        // constrained to that appearance theme via appear_to_surface_data + appearance.
+        var themeJoin = theme != string.Empty ? @"
+JOIN citydb.appear_to_surface_data a2s
+  ON a2s.surface_data_id = sd.id
+JOIN citydb.appearance ap
+  ON ap.id = a2s.appearance_id" : string.Empty;
+        var themeFilter = theme != string.Empty ? "\n  AND ap.theme = @theme" : string.Empty;
+
+        var sql = $@"
 SELECT g.id,
        g.geometry_properties::text AS geometry_properties,
        sdm.texture_mapping::text AS texture_mapping,
@@ -210,15 +220,18 @@ JOIN citydb.surface_data_mapping sdm
 JOIN citydb.surface_data sd
   ON sd.id = sdm.surface_data_id
 JOIN citydb.tex_image ti
-  ON ti.id = sd.tex_image_id
+  ON ti.id = sd.tex_image_id{themeJoin}
 WHERE g.id = ANY(@ids)
   AND sdm.texture_mapping IS NOT NULL
-  AND ti.image_data IS NOT NULL
+  AND ti.image_data IS NOT NULL{themeFilter}
 ORDER BY g.id, sdm.surface_data_id";
 
         conn.Open();
         var cmd = new NpgsqlCommand(sql, conn);
         cmd.Parameters.AddWithValue("ids", sourceIds);
+        if (theme != string.Empty) {
+            cmd.Parameters.AddWithValue("theme", theme);
+        }
         var reader = cmd.ExecuteReader();
 
         while (reader.Read()) {

--- a/src/b3dm.tileset/GeometryRepository.cs
+++ b/src/b3dm.tileset/GeometryRepository.cs
@@ -200,13 +200,16 @@ public static class GeometryRepository
 
         // Optional appearance-theme filter: without it the query keeps its original shape
         // (lowest surface_data_id wins per geometry); with a theme the surface_data is
-        // constrained to that appearance theme via appear_to_surface_data + appearance.
-        var themeJoin = theme != string.Empty ? @"
-JOIN citydb.appear_to_surface_data a2s
-  ON a2s.surface_data_id = sd.id
-JOIN citydb.appearance ap
-  ON ap.id = a2s.appearance_id" : string.Empty;
-        var themeFilter = theme != string.Empty ? "\n  AND ap.theme = @theme" : string.Empty;
+        // constrained to that appearance theme. Uses an EXISTS semi-join, not a JOIN, so a
+        // surface_data referenced by several appearances sharing the theme yields one row,
+        // not N duplicate textures.
+        var themeFilter = theme != string.Empty ? @"
+  AND EXISTS (
+    SELECT 1
+    FROM citydb.appear_to_surface_data a2s
+    JOIN citydb.appearance ap ON ap.id = a2s.appearance_id
+    WHERE a2s.surface_data_id = sd.id
+      AND ap.theme = @theme)" : string.Empty;
 
         var sql = $@"
 SELECT g.id,
@@ -220,7 +223,7 @@ JOIN citydb.surface_data_mapping sdm
 JOIN citydb.surface_data sd
   ON sd.id = sdm.surface_data_id
 JOIN citydb.tex_image ti
-  ON ti.id = sd.tex_image_id{themeJoin}
+  ON ti.id = sd.tex_image_id
 WHERE g.id = ANY(@ids)
   AND sdm.texture_mapping IS NOT NULL
   AND ti.image_data IS NOT NULL{themeFilter}

--- a/src/b3dm.tileset/OctreeTiler.cs
+++ b/src/b3dm.tileset/OctreeTiler.cs
@@ -80,7 +80,7 @@ public class OctreeTiler
             }
 
             var bbox1 = new double[] { bbox.XMin, bbox.YMin, bbox.XMax, bbox.YMax, bbox.ZMin, bbox.ZMax };
-            var geometries = GeometryRepository.GetGeometrySubset(conn, inputTable.TableName, inputTable.GeometryColumn, bbox1, inputTable.EPSGCode, target_srs, inputTable.ShadersColumn, inputTable.AttributeColumns, where, inputTable.RadiusColumn, tilingSettings.KeepProjection, inputTable.IdColumn, inputTable.UseTexturePipeline);
+            var geometries = GeometryRepository.GetGeometrySubset(conn, inputTable.TableName, inputTable.GeometryColumn, bbox1, inputTable.EPSGCode, target_srs, inputTable.ShadersColumn, inputTable.AttributeColumns, where, inputTable.RadiusColumn, tilingSettings.KeepProjection, inputTable.IdColumn, inputTable.UseTexturePipeline, inputTable.Theme);
 
             if (geometries.Count > 0) {
 

--- a/src/b3dm.tileset/QuadtreeTiler.cs
+++ b/src/b3dm.tileset/QuadtreeTiler.cs
@@ -98,7 +98,7 @@ public class QuadtreeTiler
 
             byte[] bytes = null;
 
-            var geometries = GeometryRepository.GetGeometrySubset(conn, inputTable.TableName, inputTable.GeometryColumn, tile.BoundingBox, source_epsg, target_srs, inputTable.ShadersColumn, inputTable.AttributeColumns, where, inputTable.RadiusColumn, keepProjection, inputTable.IdColumn, inputTable.UseTexturePipeline);
+            var geometries = GeometryRepository.GetGeometrySubset(conn, inputTable.TableName, inputTable.GeometryColumn, tile.BoundingBox, source_epsg, target_srs, inputTable.ShadersColumn, inputTable.AttributeColumns, where, inputTable.RadiusColumn, keepProjection, inputTable.IdColumn, inputTable.UseTexturePipeline, inputTable.Theme);
             // var scale = new double[] { 1, 1, 1 };
             if (geometries.Count > 0) {
 

--- a/src/b3dm.tileset/settings/InputTable.cs
+++ b/src/b3dm.tileset/settings/InputTable.cs
@@ -8,6 +8,7 @@ public class InputTable
     public string RadiusColumn { get; set; } = string.Empty;
     public string ShadersColumn { get; set; } = string.Empty;
     public string Query { get; set; } = string.Empty;
+    public string Theme { get; set; } = string.Empty;
 
     public string LodColumn { get; set; } = string.Empty;
     public string AttributeColumns { get; set; } = string.Empty;

--- a/src/pg2b3dm.database.tests/UnitTest1.cs
+++ b/src/pg2b3dm.database.tests/UnitTest1.cs
@@ -31,6 +31,8 @@ public class UnitTest1
         await _containerPostgres.ExecScriptAsync(initScript4);
         var initScript5 = File.ReadAllText("./postgres-db/5_create_3dcitydb_texture_tables.sql");
         await _containerPostgres.ExecScriptAsync(initScript5);
+        var initScript6 = File.ReadAllText("./postgres-db/6_create_3dcitydb_appearance_tables.sql");
+        await _containerPostgres.ExecScriptAsync(initScript6);
     }
 
     [TearDown]
@@ -155,6 +157,59 @@ public class UnitTest1
         Assert.That(texturedGeometries.Count, Is.EqualTo(1));
         Assert.That(texturedGeometries[0].HasTextureData(), Is.True);
         Assert.That(texturedGeometries[0].Textures.Count, Is.EqualTo(2));
+    }
+
+    // Geometry 4 carries the same surface twice: surface_data 4 (red, theme 'summer') and
+    // surface_data 5 (blue, theme 'winter'). Selecting 'winter' must yield the blue texture -
+    // without a theme the lower surface_data_id would win.
+    [Test]
+    public void ThemeFilterSelectsTexturesOfSelectedTheme()
+    {
+        var connectionString = _containerPostgres.GetConnectionString();
+        var conn = new NpgsqlConnection(connectionString);
+
+        var withoutTheme = GetThemedGeometry(conn, string.Empty);
+        var winter = GetThemedGeometry(conn, "winter");
+
+        Assert.That(withoutTheme.Textures.Count, Is.EqualTo(2));
+        Assert.That(winter.Textures.Count, Is.EqualTo(1));
+        Assert.That(winter.Textures[0].TextureImageData, Is.EqualTo(BluePng));
+    }
+
+    // surface_data 4 is referenced by two appearances that both carry theme 'summer'. The filter
+    // is a semi-join, so that must still be one texture - a JOIN would duplicate it.
+    [Test]
+    public void ThemeFilterDeduplicatesSurfaceDataSharedByAppearances()
+    {
+        var connectionString = _containerPostgres.GetConnectionString();
+        var conn = new NpgsqlConnection(connectionString);
+
+        var summer = GetThemedGeometry(conn, "summer");
+
+        Assert.That(summer.Textures.Count, Is.EqualTo(1));
+        Assert.That(summer.Textures[0].TextureImageData, Is.EqualTo(RedPng));
+    }
+
+    private static readonly byte[] RedPng = Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC");
+    private static readonly byte[] BluePng = Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGNgYPgPAAEDAQAIicLsAAAAAElFTkSuQmCC");
+
+    private static GeometryRecord GetThemedGeometry(NpgsqlConnection conn, string theme)
+    {
+        var geometries = GeometryRepository.GetGeometrySubset(
+            conn,
+            "citydb.geometry_data",
+            "geometry",
+            new double[] { 29, 29, 32, 32 },
+            4326,
+            4326,
+            keepProjection: true,
+            idColumn: "id",
+            includeTextures: true,
+            theme: theme
+        );
+
+        Assert.That(geometries.Count, Is.EqualTo(1));
+        return geometries[0];
     }
 
     [Test]

--- a/src/pg2b3dm.database.tests/UnitTest1.cs
+++ b/src/pg2b3dm.database.tests/UnitTest1.cs
@@ -123,6 +123,18 @@ public class UnitTest1
         Assert.That(hasIdColumn, Is.True);
     }
 
+    // A theme nobody wrote bakes an untextured tileset that otherwise looks fine, so the caller
+    // needs to hear about the typo before tiling, not after opening the viewer.
+    [Test]
+    public void DetectWhetherThemeExists()
+    {
+        var connectionString = _containerPostgres.GetConnectionString();
+        var conn = new NpgsqlConnection(connectionString);
+
+        Assert.That(CityDbRepository.HasTheme(conn, "winter"), Is.True);
+        Assert.That(CityDbRepository.HasTheme(conn, "wintr"), Is.False);
+    }
+
     [Test]
     public void TextureCheckIsPerTile()
     {

--- a/src/pg2b3dm.database.tests/UnitTest1.cs
+++ b/src/pg2b3dm.database.tests/UnitTest1.cs
@@ -13,6 +13,29 @@ public class UnitTest1
 {
     private PostgreSqlContainer _containerPostgres;
 
+    // The two 1x1 textures of the appearance fixture, so a theme test can name what it expects.
+    private static readonly byte[] RedPng = Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC");
+    private static readonly byte[] BluePng = Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGNgYPgPAAEDAQAIicLsAAAAAElFTkSuQmCC");
+
+    private static GeometryRecord GetThemedGeometry(NpgsqlConnection conn, string theme)
+    {
+        var geometries = GeometryRepository.GetGeometrySubset(
+            conn,
+            "citydb.geometry_data",
+            "geometry",
+            new double[] { 29, 29, 32, 32 },
+            4326,
+            4326,
+            keepProjection: true,
+            idColumn: "id",
+            includeTextures: true,
+            theme: theme
+        );
+
+        Assert.That(geometries.Count, Is.EqualTo(1));
+        return geometries[0];
+    }
+
     [SetUp]
     public async Task Setup()
     {
@@ -160,8 +183,9 @@ public class UnitTest1
     }
 
     // Geometry 4 carries the same surface twice: surface_data 4 (red, theme 'summer') and
-    // surface_data 5 (blue, theme 'winter'). Selecting 'winter' must yield the blue texture -
-    // without a theme the lower surface_data_id would win.
+    // surface_data 5 (blue, theme 'winter'). Unfiltered, both mappings come back and the renderer
+    // takes the first per objectId, which is the lower surface_data_id - the red one. Selecting
+    // 'winter' must narrow that to the blue texture instead.
     [Test]
     public void ThemeFilterSelectsTexturesOfSelectedTheme()
     {
@@ -169,9 +193,11 @@ public class UnitTest1
         var conn = new NpgsqlConnection(connectionString);
 
         var withoutTheme = GetThemedGeometry(conn, string.Empty);
+        var blankTheme = GetThemedGeometry(conn, "  ");
         var winter = GetThemedGeometry(conn, "winter");
 
         Assert.That(withoutTheme.Textures.Count, Is.EqualTo(2));
+        Assert.That(blankTheme.Textures.Count, Is.EqualTo(2));
         Assert.That(winter.Textures.Count, Is.EqualTo(1));
         Assert.That(winter.Textures[0].TextureImageData, Is.EqualTo(BluePng));
     }
@@ -188,28 +214,6 @@ public class UnitTest1
 
         Assert.That(summer.Textures.Count, Is.EqualTo(1));
         Assert.That(summer.Textures[0].TextureImageData, Is.EqualTo(RedPng));
-    }
-
-    private static readonly byte[] RedPng = Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC");
-    private static readonly byte[] BluePng = Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGNgYPgPAAEDAQAIicLsAAAAAElFTkSuQmCC");
-
-    private static GeometryRecord GetThemedGeometry(NpgsqlConnection conn, string theme)
-    {
-        var geometries = GeometryRepository.GetGeometrySubset(
-            conn,
-            "citydb.geometry_data",
-            "geometry",
-            new double[] { 29, 29, 32, 32 },
-            4326,
-            4326,
-            keepProjection: true,
-            idColumn: "id",
-            includeTextures: true,
-            theme: theme
-        );
-
-        Assert.That(geometries.Count, Is.EqualTo(1));
-        return geometries[0];
     }
 
     [Test]

--- a/src/pg2b3dm.database.tests/pg2b3dm.database.tests.csproj
+++ b/src/pg2b3dm.database.tests/pg2b3dm.database.tests.csproj
@@ -50,6 +50,9 @@
     <None Update="postgres-db\5_create_3dcitydb_texture_tables.sql">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="postgres-db\6_create_3dcitydb_appearance_tables.sql">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="testfixtures\delaware.sqlite">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/pg2b3dm.database.tests/postgres-db/6_create_3dcitydb_appearance_tables.sql
+++ b/src/pg2b3dm.database.tests/postgres-db/6_create_3dcitydb_appearance_tables.sql
@@ -1,0 +1,81 @@
+-- 3DCityDB v5 appearance graph, used by the --theme filter.
+-- Additive on top of 5_create_3dcitydb_texture_tables.sql: a fourth geometry carrying two
+-- surface_data (one per theme) so a theme selection can be told apart from "lowest
+-- surface_data_id wins". Kept outside the bounding boxes the other texture tests query.
+
+CREATE TABLE IF NOT EXISTS citydb.appearance
+(
+    id BIGINT PRIMARY KEY,
+    objectid TEXT,
+    theme TEXT
+);
+
+CREATE TABLE IF NOT EXISTS citydb.appear_to_surface_data
+(
+    id BIGSERIAL PRIMARY KEY,
+    appearance_id BIGINT NOT NULL,
+    surface_data_id BIGINT
+);
+
+INSERT INTO citydb.geometry_data (id, geometry, geometry_properties)
+VALUES
+    (
+        4,
+        'SRID=4326;POLYGON Z ((30 30 0, 31 30 0, 30 31 0, 30 30 0))'::geometry,
+        '{"type": 6, "children": [{"type": 3, "objectId": "surface_4", "geometryIndex": 0}]}'::jsonb
+    )
+ON CONFLICT (id) DO NOTHING;
+
+-- Two 1x1 PNGs with distinct pixels (red / blue), so a test can tell which theme was baked.
+INSERT INTO citydb.tex_image (id, image_uri, mime_type, image_data)
+VALUES
+    (
+        3,
+        'red.png',
+        'image/png',
+        decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC', 'base64')
+    ),
+    (
+        4,
+        'blue.png',
+        'image/png',
+        decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGNgYPgPAAEDAQAIicLsAAAAAElFTkSuQmCC', 'base64')
+    )
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO citydb.surface_data (id, tex_image_id)
+VALUES
+    (4, 3),
+    (5, 4)
+ON CONFLICT (id) DO NOTHING;
+
+-- Same surface of the same geometry, textured twice - the themes are what tell them apart.
+INSERT INTO citydb.surface_data_mapping (geometry_data_id, surface_data_id, texture_mapping)
+VALUES
+    (
+        4,
+        4,
+        '{"surface_4":[[[0.0,0.0],[1.0,0.0],[0.0,1.0],[0.0,0.0]]]}'::jsonb
+    ),
+    (
+        4,
+        5,
+        '{"surface_4":[[[0.0,0.0],[1.0,0.0],[0.0,1.0],[0.0,0.0]]]}'::jsonb
+    )
+ON CONFLICT DO NOTHING;
+
+-- 'summer' is carried by two appearances that both reference surface_data 4: the semi-join must
+-- still yield one texture row, not one per appearance.
+INSERT INTO citydb.appearance (id, objectid, theme)
+VALUES
+    (1, 'appearance_summer_a', 'summer'),
+    (2, 'appearance_winter', 'winter'),
+    (3, 'appearance_summer_b', 'summer')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO citydb.appear_to_surface_data (appearance_id, surface_data_id)
+VALUES
+    (1, 4),
+    (3, 4),
+    (2, 5)
+ON CONFLICT DO NOTHING;

--- a/src/pg2b3dm/Options.cs
+++ b/src/pg2b3dm/Options.cs
@@ -28,6 +28,9 @@ public class Options
     [Option('q', "query", Required = false, Default = "", HelpText = "Query parameter")]
     public string Query { get; set; }
 
+    [Option("theme", Required = false, Default = "", HelpText = "3DCityDB v5+ appearance theme to select textures from (filters the surface_data via appearance). Empty = no theme filter (lowest surface_data_id wins).")]
+    public string Theme { get; set; }
+
     [Option("copyright", Required = false, Default = "", HelpText = "glTF asset copyright")]
     public string Copyright { get; set; }
 

--- a/src/pg2b3dm/Program.cs
+++ b/src/pg2b3dm/Program.cs
@@ -122,7 +122,7 @@ class Program
                 Console.WriteLine($"Warning: column 'id' missing in {inputTable.TableName}, texture pipeline disabled.");
             }
             Console.WriteLine($"Texture pipeline enabled: {inputTable.UseTexturePipeline}");
-            if (inputTable.Theme != String.Empty) {
+            if (!String.IsNullOrWhiteSpace(inputTable.Theme)) {
                 Console.WriteLine($"Texture theme filter: {inputTable.Theme}");
             }
 

--- a/src/pg2b3dm/Program.cs
+++ b/src/pg2b3dm/Program.cs
@@ -124,6 +124,13 @@ class Program
             Console.WriteLine($"Texture pipeline enabled: {inputTable.UseTexturePipeline}");
             if (!String.IsNullOrWhiteSpace(inputTable.Theme)) {
                 Console.WriteLine($"Texture theme filter: {inputTable.Theme}");
+                // A theme no appearance carries is not an error to the tiler: it bakes a complete
+                // tileset in which every tile is untextured, so a typo only shows up in the viewer.
+                // Say it once here, not per tile - with a theme filter most tiles are legitimately
+                // untextured.
+                if (inputTable.UseTexturePipeline && !CityDbRepository.HasTheme(conn, inputTable.Theme)) {
+                    Console.WriteLine($"Warning: no appearance has theme '{inputTable.Theme}', all tiles will be untextured.");
+                }
             }
 
             var skipCreateTiles = (bool)o.SkipCreateTiles;

--- a/src/pg2b3dm/Program.cs
+++ b/src/pg2b3dm/Program.cs
@@ -73,6 +73,7 @@ class Program
             inputTable.TableName = o.GeometryTable;
             inputTable.GeometryColumn = o.GeometryColumn;
             inputTable.Query = o.Query;
+            inputTable.Theme = o.Theme;
             inputTable.RadiusColumn = o.RadiusColumn;
             inputTable.ShadersColumn = o.ShadersColumn;
             inputTable.AttributeColumns = o.AttributeColumns;
@@ -121,6 +122,9 @@ class Program
                 Console.WriteLine($"Warning: column 'id' missing in {inputTable.TableName}, texture pipeline disabled.");
             }
             Console.WriteLine($"Texture pipeline enabled: {inputTable.UseTexturePipeline}");
+            if (inputTable.Theme != String.Empty) {
+                Console.WriteLine($"Texture theme filter: {inputTable.Theme}");
+            }
 
             var skipCreateTiles = (bool)o.SkipCreateTiles;
             Console.WriteLine("Skip create tiles: " + skipCreateTiles);


### PR DESCRIPTION
## What

Adds an optional `--theme <name>` flag to the 3DCityDB v5+ texture pipeline. When set, only textures belonging to that appearance theme are exported.

## Why

3DCityDB v5 can hold many appearance **themes** over one shared geometry (e.g. an aerial photo theme plus per-period analysis themes), each theme being a set of `appearance` rows that reference `surface_data` via `appear_to_surface_data`.

Today the texture-enrichment query joins `geometry_data -> surface_data_mapping -> surface_data -> tex_image` with no appearance filter and `ORDER BY g.id, sdm.surface_data_id`, so a geometry with multiple mappings always renders the **lowest `surface_data_id`** and silently ignores every other theme. There is no way to ask for a specific theme.

This matters for use cases where one building geometry carries several textured "layers" (analysis results, thematic overlays) and you want to publish one tileset per theme from a single shared geometry, rather than duplicating geometry per theme.

## How

- New `--theme` option (`Options.cs`), default empty. Threaded through `InputTable` -> both tilers -> `GetGeometrySubset` -> `EnrichWithTextures`, mirroring the existing plumbing for `IdColumn` / `Query`.
- When a theme is given, `EnrichWithTextures` adds an **`EXISTS` semi-join** on `appear_to_surface_data` + `appearance` filtering `appearance.theme = @theme`. A semi-join (not a plain JOIN) is used so a `surface_data` referenced by multiple appearances sharing the theme still yields exactly one row, never duplicate embedded textures.
- The theme value is passed as an Npgsql parameter (`@theme`) - no string interpolation of user input.

## Backwards compatibility

- Empty theme (the default) reproduces the previous query **verbatim** - zero behaviour change for existing users.
- All new method parameters are optional with safe defaults; existing call sites and unit tests compile unchanged.

## Testing

Verified on a 3DCityDB v5.0 database (Luxembourg 3D open-data) where `geometry_data` id=1 carries two mappings: a photo texture (theme `Aerial`, lower `surface_data_id`) and a hand-authored analysis texture (theme `test`).

- No `--theme`: exported glb embeds the photo JPEG (39066 B) - unchanged baseline.
- `--theme test`: exported glb embeds the analysis PNG (393 B), a single texture, no duplication.
